### PR TITLE
Enhance Gomoku UI with scoreboard and board size options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is a static HTML/CSS/JS Gomoku (五子棋) game that supports both two-play
   - **Undo Last Move**: Allows reverting the last move.
   - **Restart Game**: Provides an option to restart the game with confirmation.
   - **Win Highlighting**: The final move that results in a win is highlighted.
+  - **Scoreboard**: Tracks wins for both players and persists results with `localStorage`.
+  - **Board Size Selection**: Choose between multiple board sizes for different difficulty levels.
 
 ## File Structure
 

--- a/game.js
+++ b/game.js
@@ -1,21 +1,32 @@
-const BOARD_SIZE = 15;
+let boardSize = 15; // 棋盤大小，可由使用者選擇
 let board = [];
 let currentPlayer = '黑棋';
 let gameOver = false;
 let movesStack = [];
 let gameMode = 'pvp'; // 'pvp' 為雙人對戰，'ai' 為 AI 對戰
 
+// 紀錄勝負並存入 localStorage
+let scoreBlack = parseInt(localStorage.getItem('scoreBlack')) || 0;
+let scoreWhite = parseInt(localStorage.getItem('scoreWhite')) || 0;
+
 const boardDiv = document.getElementById('board');
 const undoBtn = document.getElementById('undoBtn');
 const restartBtn = document.getElementById('restartBtn');
 const modeRadios = document.getElementsByName('mode');
+const boardSizeSelect = document.getElementById('boardSize');
+const scoreBlackSpan = document.getElementById('scoreBlack');
+const scoreWhiteSpan = document.getElementById('scoreWhite');
+
+updateScoreboard();
 
 function initBoard() {
-  board = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(''));
+  board = Array.from({ length: boardSize }, () => Array(boardSize).fill(''));
   boardDiv.innerHTML = '';
+  boardDiv.style.gridTemplateColumns = `repeat(${boardSize}, 1fr)`;
+  boardDiv.style.gridTemplateRows = `repeat(${boardSize}, 1fr)`;
   // 建立棋盤格子
-  for (let i = 0; i < BOARD_SIZE; i++) {
-    for (let j = 0; j < BOARD_SIZE; j++) {
+  for (let i = 0; i < boardSize; i++) {
+    for (let j = 0; j < boardSize; j++) {
       const cell = document.createElement('div');
       cell.classList.add('cell');
       cell.dataset.row = i;
@@ -27,6 +38,7 @@ function initBoard() {
   currentPlayer = '黑棋';
   gameOver = false;
   movesStack = [];
+  updateScoreboard();
 }
 
 function onCellClick(e) {
@@ -57,7 +69,7 @@ function makeMove(row, col, player) {
 }
 
 function updateCell(row, col, player) {
-  const index = row * BOARD_SIZE + col;
+  const index = row * boardSize + col;
   const cell = boardDiv.children[index];
   if (player === '黑棋') {
     cell.innerHTML = `<svg width="100%" height="100%" viewBox="0 0 100 100" class="chess-piece"><circle cx="50" cy="50" r="40" fill="black" /></svg>`;
@@ -83,7 +95,7 @@ function checkWin(row, col, player) {
 function countConsecutive(row, col, player, deltaRow, deltaCol) {
   let count = 0;
   let r = row, c = col;
-  while (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE && board[r][c] === player) {
+  while (r >= 0 && r < boardSize && c >= 0 && c < boardSize && board[r][c] === player) {
     count++;
     r += deltaRow;
     c += deltaCol;
@@ -93,9 +105,17 @@ function countConsecutive(row, col, player, deltaRow, deltaCol) {
 
 function highlightWin(row, col, player) {
   // 將獲勝者的連線高亮顯示 (此處僅作簡單提示，可擴充實作以高亮所有五子)
-  const index = row * BOARD_SIZE + col;
+  const index = row * boardSize + col;
   const cell = boardDiv.children[index];
   cell.style.backgroundColor = "#ff0";
+  if (player === '黑棋') {
+    scoreBlack++;
+    localStorage.setItem('scoreBlack', scoreBlack);
+  } else {
+    scoreWhite++;
+    localStorage.setItem('scoreWhite', scoreWhite);
+  }
+  updateScoreboard();
 }
 
 function undo() {
@@ -103,7 +123,7 @@ function undo() {
   // 撤銷上一步
   const lastMove = movesStack.pop();
   board[lastMove.row][lastMove.col] = '';
-  const index = lastMove.row * BOARD_SIZE + lastMove.col;
+  const index = lastMove.row * boardSize + lastMove.col;
   const cell = boardDiv.children[index];
   cell.innerHTML = '';
   gameOver = false;
@@ -118,8 +138,8 @@ function restart() {
 
 function aiMove() {
   let emptyCells = [];
-  for (let i = 0; i < BOARD_SIZE; i++) {
-    for (let j = 0; j < BOARD_SIZE; j++) {
+  for (let i = 0; i < boardSize; i++) {
+    for (let j = 0; j < boardSize; j++) {
       if (board[i][j] === '') {
         emptyCells.push({ i, j });
       }
@@ -200,11 +220,16 @@ function evaluateMove(row, col, player) {
 function hasNeighbor(row, col) {
   for (let i = row - 1; i <= row + 1; i++) {
     for (let j = col - 1; j <= col + 1; j++) {
-      if (i < 0 || i >= BOARD_SIZE || j < 0 || j >= BOARD_SIZE) continue;
+      if (i < 0 || i >= boardSize || j < 0 || j >= boardSize) continue;
       if (board[i][j] !== '') return true;
     }
   }
   return false;
+}
+
+function updateScoreboard() {
+  scoreBlackSpan.textContent = scoreBlack;
+  scoreWhiteSpan.textContent = scoreWhite;
 }
 
 undoBtn.addEventListener('click', undo);
@@ -214,6 +239,11 @@ modeRadios.forEach(radio => {
     gameMode = document.querySelector('input[name="mode"]:checked').value;
     restart();
   });
+});
+
+boardSizeSelect.addEventListener('change', () => {
+  boardSize = parseInt(boardSizeSelect.value);
+  restart();
 });
 
 // 初始化遊戲

--- a/index.html
+++ b/index.html
@@ -15,11 +15,25 @@
       <!-- 五子棋棋盤 -->
       <div id="board"></div>
     </section>
+    <section id="scoreboard">
+      黑棋勝：<span id="scoreBlack">0</span> | 白棋勝：<span id="scoreWhite">0</span>
+    </section>
     <section id="controls">
       <!-- 遊戲模式選擇 -->
       <div id="mode-select">
         <label><input type="radio" name="mode" value="pvp" checked> 雙人對戰</label>
         <label><input type="radio" name="mode" value="ai"> AI 對戰</label>
+      </div>
+      <!-- 棋盤大小選擇 -->
+      <div id="board-size-select">
+        <label for="boardSize">棋盤大小：</label>
+        <select id="boardSize">
+          <option value="9">9x9</option>
+          <option value="11">11x11</option>
+          <option value="13">13x13</option>
+          <option value="15" selected>15x15</option>
+          <option value="19">19x19</option>
+        </select>
       </div>
       <!-- 按鈕 -->
       <button id="undoBtn">撤銷上一步</button>

--- a/style.css
+++ b/style.css
@@ -82,6 +82,15 @@ main {
   margin-bottom: 1rem;
 }
 
+#board-size-select {
+  margin-bottom: 1rem;
+}
+
+#scoreboard {
+  margin: 0.5rem 0;
+  font-size: 1.2rem;
+}
+
 @media (max-width: 600px) {
   header, main {
     padding: 0.5rem;


### PR DESCRIPTION
## Summary
- add scoreboard display and board size selector in the UI
- track wins in localStorage
- allow choosing board sizes from 9x9 up to 19x19
- adjust board rendering based on selected size
- update README with new features

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fa10a9ac0832fb1aa209b851d60bd

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on enhancing the user interface and functionality of a chess game by adding a scoreboard, allowing board size selection, and improving CSS styling. It also includes updates to the game logic to support these new features.

### Detailed summary
- Added `#board-size-select` for selecting board sizes.
- Introduced `#scoreboard` to display player scores.
- Updated CSS for `#mode-select`, `#scoreboard`, and `#board-size-select`.
- Modified game logic to handle variable board sizes.
- Implemented score tracking with `localStorage`.
- Updated the scoreboard display after each game.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->